### PR TITLE
feat: add session replay selector masking fields

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -122,6 +122,15 @@ const onInstall = () => {
   }
   if (data.advanced_session_replay_token) {
     options.session_replay = { token: data.advanced_session_replay_token };
+    if (data.advanced_session_replay_block_selector) {
+      options.session_replay.block_selector = data.advanced_session_replay_block_selector;
+    }
+    if (data.advanced_session_replay_ignore_selector) {
+      options.session_replay.ignore_selector = data.advanced_session_replay_ignore_selector;
+    }
+    if (data.advanced_session_replay_mask_text_selector) {
+      options.session_replay.mask_text_selector = data.advanced_session_replay_mask_text_selector;
+    }
   }
   if (data.advanced_experimentation_token) {
     options.experimentation = { token: data.advanced_experimentation_token };

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,17 @@ const normalizeTable = (table, prop, val) => {
   return false;
 };
 
+// Flatten a single-column SIMPLE_TABLE into a string array, dropping empty rows.
+const normalizeList = (table, prop) => {
+  if (!table || !table.length) return false;
+  const out = [];
+  for (let i = 0; i < table.length; i++) {
+    const v = table[i][prop];
+    if (v) out.push(v);
+  }
+  return out.length ? out : false;
+};
+
 // Normalize the three column table
 const normalizeThreeColumnTable = (table, prop, val, behavior) => {
   if (table && table.length) {
@@ -137,6 +148,10 @@ const onInstall = () => {
   }
   if (data.advanced_bot_detection) {
     options.bot_detection = data.advanced_bot_detection;
+  }
+  const urlQueryParamsBlocklist = normalizeList(data.advanced_url_query_params_blocklist, 'param');
+  if (urlQueryParamsBlocklist) {
+    options.url_query_params_blocklist = urlQueryParamsBlocklist;
   }
   const default_event_properties_table = normalizeTable(data.default_event_properties, 'property', 'value');
   const default_event_properties = mergeWithObject(default_event_properties_table, data.default_event_properties_object);

--- a/template.tpl
+++ b/template.tpl
@@ -134,6 +134,30 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "type": "TEXT",
+            "name": "advanced_session_replay_block_selector",
+            "displayName": "Session Replay Block Selector",
+            "simpleValueType": true,
+            "help": "CSS selector for elements that should be fully blocked from capture (replaced with a placeholder box). Comma-separated selectors are supported.",
+            "valueHint": ".payment-form, #card-number"
+          },
+          {
+            "type": "TEXT",
+            "name": "advanced_session_replay_ignore_selector",
+            "displayName": "Session Replay Ignore Selector",
+            "simpleValueType": true,
+            "help": "CSS selector for elements that bypass masking — text is captured unredacted even when mask_all_text is active. Comma-separated selectors are supported.",
+            "valueHint": ".public-content, #hero-text"
+          },
+          {
+            "type": "TEXT",
+            "name": "advanced_session_replay_mask_text_selector",
+            "displayName": "Session Replay Mask Text Selector",
+            "simpleValueType": true,
+            "help": "CSS selector for elements whose text should be masked. Comma-separated selectors are supported.",
+            "valueHint": ".user-email, #account-name"
+          },
+          {
+            "type": "TEXT",
             "name": "advanced_experimentation_token",
             "displayName": "Experimentation Token",
             "simpleValueType": true,
@@ -1170,6 +1194,15 @@ const onInstall = () => {
   }
   if (data.advanced_session_replay_token) {
     options.session_replay = { token: data.advanced_session_replay_token };
+    if (data.advanced_session_replay_block_selector) {
+      options.session_replay.block_selector = data.advanced_session_replay_block_selector;
+    }
+    if (data.advanced_session_replay_ignore_selector) {
+      options.session_replay.ignore_selector = data.advanced_session_replay_ignore_selector;
+    }
+    if (data.advanced_session_replay_mask_text_selector) {
+      options.session_replay.mask_text_selector = data.advanced_session_replay_mask_text_selector;
+    }
   }
   if (data.advanced_experimentation_token) {
     options.experimentation = { token: data.advanced_experimentation_token };

--- a/template.tpl
+++ b/template.tpl
@@ -285,6 +285,20 @@ ___TEMPLATE_PARAMETERS___
             "help": "Enable behavioral bot detection signal collection. When enabled, the SDK collects mouse, scroll, click, and keyboard behavioral signals and attaches them to events for server-side scoring."
           },
           {
+            "type": "SIMPLE_TABLE",
+            "name": "advanced_url_query_params_blocklist",
+            "displayName": "URL Query Params Blocklist",
+            "simpleTableColumns": [
+              {
+                "defaultValue": "",
+                "displayName": "Param",
+                "name": "param",
+                "type": "TEXT"
+              }
+            ],
+            "help": "Query parameter names to remove from captured URL fields (page_url, referrer, etc.) before events are sent."
+          },
+          {
             "type": "TEXT",
             "name": "advanced_user_id_override",
             "displayName": "Ours User ID Override",
@@ -1106,6 +1120,17 @@ const normalizeTable = (table, prop, val) => {
   return false;
 };
 
+// Flatten a single-column SIMPLE_TABLE into a string array, dropping empty rows.
+const normalizeList = (table, prop) => {
+  if (!table || !table.length) return false;
+  const out = [];
+  for (let i = 0; i < table.length; i++) {
+    const v = table[i][prop];
+    if (v) out.push(v);
+  }
+  return out.length ? out : false;
+};
+
 // Normalize the three column table
 const normalizeThreeColumnTable = (table, prop, val, behavior) => {
   if (table && table.length) {
@@ -1209,6 +1234,10 @@ const onInstall = () => {
   }
   if (data.advanced_bot_detection) {
     options.bot_detection = data.advanced_bot_detection;
+  }
+  const urlQueryParamsBlocklist = normalizeList(data.advanced_url_query_params_blocklist, 'param');
+  if (urlQueryParamsBlocklist) {
+    options.url_query_params_blocklist = urlQueryParamsBlocklist;
   }
   const default_event_properties_table = normalizeTable(data.default_event_properties, 'property', 'value');
   const default_event_properties = mergeWithObject(default_event_properties_table, data.default_event_properties_object);


### PR DESCRIPTION
## Summary

- Adds `block_selector`, `ignore_selector`, and `mask_text_selector` UI fields to the GTM template (under the Session Replay Token field in Advanced)
- Wires all three through to `options.session_replay` in both `template.tpl` and `src/main.js`
- Each field accepts comma-separated CSS selectors and includes a hint showing the format

Mirrors the CDP changes from martech PR [#3926](https://github.com/with-ours/martech/pull/3926).

## Test plan

- [ ] Set a Session Replay Token and `block_selector` — confirm `session_replay.block_selector` is passed to `ours('init', ...)`
- [ ] Confirm fields left blank are omitted from the `session_replay` object entirely
- [ ] Confirm `ignore_selector` and `mask_text_selector` behave the same way