### PR TITLE
feat: expose session replay mask_all_text and excludePaths options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -142,6 +142,13 @@ const onInstall = () => {
     if (data.advanced_session_replay_mask_text_selector) {
       options.session_replay.mask_text_selector = data.advanced_session_replay_mask_text_selector;
     }
+    if (data.advanced_session_replay_mask_all_text) {
+      options.session_replay.mask_all_text = data.advanced_session_replay_mask_all_text;
+    }
+    const sessionReplayExcludePaths = normalizeList(data.advanced_session_replay_exclude_paths, 'path');
+    if (sessionReplayExcludePaths) {
+      options.session_replay.excludePaths = sessionReplayExcludePaths;
+    }
   }
   if (data.advanced_experimentation_token) {
     options.experimentation = { token: data.advanced_experimentation_token };

--- a/template.tpl
+++ b/template.tpl
@@ -157,6 +157,27 @@ ___TEMPLATE_PARAMETERS___
             "valueHint": ".user-email, #account-name"
           },
           {
+            "type": "CHECKBOX",
+            "name": "advanced_session_replay_mask_all_text",
+            "checkboxText": "Mask All Text",
+            "simpleValueType": true,
+            "help": "When enabled, all text content is masked (redacted) in session replays. Use the Ignore Selector above to opt specific elements back in."
+          },
+          {
+            "type": "SIMPLE_TABLE",
+            "name": "advanced_session_replay_exclude_paths",
+            "displayName": "Session Replay Exclude Paths",
+            "simpleTableColumns": [
+              {
+                "defaultValue": "",
+                "displayName": "Path",
+                "name": "path",
+                "type": "TEXT"
+              }
+            ],
+            "help": "Path denylist (glob patterns matched against location.pathname). Recording is skipped on matching paths. Takes precedence over any allowlist."
+          },
+          {
             "type": "TEXT",
             "name": "advanced_experimentation_token",
             "displayName": "Experimentation Token",
@@ -1227,6 +1248,13 @@ const onInstall = () => {
     }
     if (data.advanced_session_replay_mask_text_selector) {
       options.session_replay.mask_text_selector = data.advanced_session_replay_mask_text_selector;
+    }
+    if (data.advanced_session_replay_mask_all_text) {
+      options.session_replay.mask_all_text = data.advanced_session_replay_mask_all_text;
+    }
+    const sessionReplayExcludePaths = normalizeList(data.advanced_session_replay_exclude_paths, 'path');
+    if (sessionReplayExcludePaths) {
+      options.session_replay.excludePaths = sessionReplayExcludePaths;
     }
   }
   if (data.advanced_experimentation_token) {


### PR DESCRIPTION
## Summary
Wires two more CDP `session_replay` options through the GTM template, following the same pattern as the recently merged selector fields (#33) and the `url_query_params_blocklist` option:

- **`mask_all_text`** — `CHECKBOX` (`advanced_session_replay_mask_all_text`). When enabled, all text content is masked in session replays; the existing Ignore Selector opts elements back in.
- **`excludePaths`** — single-column `SIMPLE_TABLE` (`advanced_session_replay_exclude_paths`), flattened via the shared `normalizeList(..., 'path')` helper. Path denylist (glob patterns vs `location.pathname`); recording is skipped on matching paths.

Both new mappings are nested inside the existing `if (data.advanced_session_replay_token)` block alongside the selector fields, and applied to both `template.tpl` and `src/main.js` in lockstep.

## Notes
- No `___TESTS___` / `___WEB_PERMISSIONS___` / README changes — consistent with the prior session-replay and blocklist PRs (these options need no new permissions).
- `recordOnPaths`, `sampleRate`, and `alwaysRecordEvents` remain unexposed; easy to add the same way later.